### PR TITLE
Use Services global variable

### DIFF
--- a/chrome/content/api/Utilities/implementation.js
+++ b/chrome/content/api/Utilities/implementation.js
@@ -1,7 +1,6 @@
 /* eslint-disable object-shorthand */
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var win = Services.wm.getMostRecentWindow("mail:3pane"); 
 
 

--- a/chrome/content/filterTemplate.js
+++ b/chrome/content/filterTemplate.js
@@ -7,7 +7,6 @@
     For details, please refer to license.txt in the root folder of this extension
 
   END LICENSE BLOCK */
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 var FilterTemplate = {
     loadTemplate : function loadTemplate() {

--- a/chrome/content/qf-advancedTab.js
+++ b/chrome/content/qf-advancedTab.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 QuickFolders.AdvancedTab = {
   ADVANCED_FLAGS: QuickFolders.Util.ADVANCED_FLAGS,
   get folder() {

--- a/chrome/content/quickfolders-bookmarks.js
+++ b/chrome/content/quickfolders-bookmarks.js
@@ -7,7 +7,6 @@ For details, please refer to license.txt in the root folder of this extension
 
 END LICENSE BLOCK */
 //QuickFolders.Util.logDebug('Defining QuickFolders.bookmarks...');
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { MailUtils } = ChromeUtils.import("resource:///modules/MailUtils.jsm");
 var {MailServices} = ChromeUtils.import("resource:///modules/MailServices.jsm");
 

--- a/chrome/content/quickfolders-composer.js
+++ b/chrome/content/quickfolders-composer.js
@@ -6,8 +6,6 @@
 
   END LICENSE BLOCK */
 
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 // adding getter for main instance as a property
 Object.defineProperty(QuickFolders, "MainQuickFolders", 
 { get : function QF_getMainInstance() {

--- a/chrome/content/quickfolders-filterWorker.js
+++ b/chrome/content/quickfolders-filterWorker.js
@@ -8,8 +8,6 @@
 
   END LICENSE BLOCK */
   
-var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 QuickFolders.FilterWorker = {
 
   bundle: null,

--- a/chrome/content/quickfolders-folder-category-dlg.js
+++ b/chrome/content/quickfolders-folder-category-dlg.js
@@ -8,8 +8,6 @@
 
   END LICENSE BLOCK */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-  
 var QuickFolders = window.arguments[0];
 
 var CatWin = {

--- a/chrome/content/quickfolders-folderTree.js
+++ b/chrome/content/quickfolders-folderTree.js
@@ -8,8 +8,6 @@
 
   END LICENSE BLOCK */
 	
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 // we shall use a dictionary for the folder customization (minimum version Thunderbird 19 for JSON support)
 
 

--- a/chrome/content/quickfolders-interface.js
+++ b/chrome/content/quickfolders-interface.js
@@ -8,7 +8,6 @@
   END LICENSE BLOCK */
 
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
 
 QuickFolders.Interface = {
@@ -5289,7 +5288,6 @@ QuickFolders.Interface = {
         // make it easy to hit return to jump into folder instead:
         // isSelected = QuickFolders_MySelectFolder(matches[0].uri);
         setTimeout( function() {
-            var {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
             let fm = Services.focus;
             fm.setFocus(menupopup, fm.MOVEFOCUS_FIRST + fm.FLAG_SHOWRING);
             let fC = menupopup.firstChild;
@@ -7255,7 +7253,6 @@ QuickFolders.Interface = {
     trans.init(null);
     trans.addDataFlavor("text/unicode");
     trans.addDataFlavor("text/plain");
-    var {Services} = ChromeUtils.import('resource://gre/modules/Services.jsm');
     
     if (Services.clipboard) {
       Services.clipboard.getData(trans, Services.clipboard.kGlobalClipboard);

--- a/chrome/content/quickfolders-model.js
+++ b/chrome/content/quickfolders-model.js
@@ -7,7 +7,6 @@
 
   END LICENSE BLOCK */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
 var { MailUtils } = ChromeUtils.import("resource:///modules/MailUtils.jsm");
 

--- a/chrome/content/quickfolders-preferences.js
+++ b/chrome/content/quickfolders-preferences.js
@@ -10,7 +10,6 @@
 */
 
 //export  {QuickFolders.Preferences};
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 QuickFolders.Preferences = {
 	get isDebug() {

--- a/chrome/content/quickfolders-util.js
+++ b/chrome/content/quickfolders-util.js
@@ -8,7 +8,6 @@
   END LICENSE BLOCK */
 
  
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm"); 
 
 var QuickFolders_ConsoleService = null;
@@ -1389,7 +1388,6 @@ allowUndo = true)`
   
   findMailTab: function findMailTab(tabmail, URL) {
     const util = QuickFolders.Util;
-    var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
     // mail: tabmail.tabInfo[n].browser   
     let baseURL = util.getBaseURI(URL),
         numTabs = util.getTabInfoLength(tabmail);
@@ -2336,7 +2334,6 @@ var QuickFolders_TabURIopener = {
 
 // the following adds the notifyTools API as a util method to communicate with the background page
 // this mechanism will be used to replace legacy code with API calls.
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { ExtensionParent } = ChromeUtils.import("resource://gre/modules/ExtensionParent.jsm");
 QuickFolders.Util.extension = ExtensionParent.GlobalManager.getExtension("quickfolders@curious.be");
 Services.scriptloader.loadSubScript(

--- a/chrome/content/quickfolders.js
+++ b/chrome/content/quickfolders.js
@@ -392,8 +392,6 @@ END LICENSE BLOCK */
 
 */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-	
 /* GLOBAL VARIABLES */
 var QuickFolders_globalHidePopupId = "",
     QuickFolders_globalLastChildPopup = null,

--- a/chrome/content/scripts/notifyTools.js
+++ b/chrome/content/scripts/notifyTools.js
@@ -19,8 +19,6 @@ var ADDON_ID = "quickfolders@curious.be";
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 var notifyTools = {
   registeredCallbacks: {},
   registeredCallbacksNextId: 1,

--- a/chrome/content/scripts/qf-composer.js
+++ b/chrome/content/scripts/qf-composer.js
@@ -1,5 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-composer.js", window, "UTF-8");
 

--- a/chrome/content/scripts/qf-customizetoolbar.js
+++ b/chrome/content/scripts/qf-customizetoolbar.js
@@ -1,5 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-preferences.js", window, "UTF-8");
 

--- a/chrome/content/scripts/qf-filterlist.js
+++ b/chrome/content/scripts/qf-filterlist.js
@@ -1,6 +1,4 @@
 /* this module is obsolete */
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-preferences.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-interface.js", window, "UTF-8");

--- a/chrome/content/scripts/qf-messageWindow.js
+++ b/chrome/content/scripts/qf-messageWindow.js
@@ -1,5 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-preferences.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-themes.js", window, "UTF-8");

--- a/chrome/content/scripts/qf-messenger.js
+++ b/chrome/content/scripts/qf-messenger.js
@@ -1,4 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
 
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders.js", window, "UTF-8");

--- a/chrome/content/scripts/qf-searchDialog.js
+++ b/chrome/content/scripts/qf-searchDialog.js
@@ -1,5 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-preferences.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfolders/content/quickfolders-util.js", window, "UTF-8");


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and also available in all system globals from version 104 https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 , and those code doesn't have to import Services.jsm if the strict_min_version is 111.